### PR TITLE
added CMakeLists.txt (for building with cmake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.6)
+project(probe C)
+
+if(UNIX)
+  find_library(MATH_LIBRARY m)
+endif()
+
+add_executable(probe
+  probe.c dots.c abin.c readPDBrecs.c geom3d.c utility.c select.c
+  parse.c atomprops.c stdconntable.c autobondrot.c hybrid_36_c.c)
+target_link_libraries(probe ${MATH_LIBRARY})
+
+install(TARGETS probe DESTINATION bin)


### PR DESCRIPTION
I don't know if you're interested in keeping yet another build script (if not, just reject this PR). Here in CCP4 we prefer cmake primarily for consistency - most of the projects that we build use cmake.
