### PR TITLE
CMake and windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.10.0)
+project(probe)
+
+if (WIN32)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif ()
+
+set(probe_SOURCES
+	abin.c
+	atomprops.c
+	autobondrot.c
+	dots.c
+	geom3d.c
+	hybrid_36_c.c
+	readPDBrecs.c
+	parse.c
+	select.c
+	stdconntable.c
+	utility.c
+	probe.c
+)
+
+set(probe_HEADERS
+	abin.h
+	atomprops.h
+	autobondrot.h
+	dots.h
+	geom3d.h
+	hybrid_36_c.h
+	parse.h
+	readPDBrecs.h
+	select.h
+	stdconntable.h
+	utility.h
+)
+
+add_executable(probe ${probe_SOURCES} ${probe_HEADERS})
+if (NOT WIN32)
+  target_link_libraries(probe m)
+endif()

--- a/autobondrot.c
+++ b/autobondrot.c
@@ -140,7 +140,7 @@ void scanXDBinputText(xformDatabase* xdb, FILE *inf, FILE *outf,
 	 }
 	 else if (s[0] == '@') { /* include file */
 	    FILE *if2 = NULL;
-	    if2 = fopen(s+1, "r");
+	    if2 = fopen(s+1, "rb");
 	    if (if2) { /* recursive call */
 	       fprintf(outf, "%s%s\n", cch, s);
 

--- a/probe.c
+++ b/probe.c
@@ -1899,7 +1899,7 @@ atom* processCommandline(int argc, char **argv, int *method, region *bboxA,
 	       }
 	       else {
 		  file++;
-		  inf = fopen(p, "r"); /*p holds autobondrot input file name*/
+		  inf = fopen(p, "rb"); /*p holds autobondrot input file name*/
 		  if (inf) {
 		     if (mabip) {
 			mabip->filenum  = file;
@@ -1965,7 +1965,7 @@ atom* processCommandline(int argc, char **argv, int *method, region *bboxA,
     else
     {
        file++;
-       inf = fopen(p, "r");
+       inf = fopen(p, "rb");
        if (inf)
        {
           strcpy(inputfilename,p); /*dcr041023*/
@@ -1992,7 +1992,7 @@ atom* processCommandline(int argc, char **argv, int *method, region *bboxA,
          DoMcMc = TRUE;
          DoHet  = TRUE;
          file++;
-         inf = fopen(p, "r");
+         inf = fopen(p, "rb");
          if (inf)
          {
             strcpy(inputfilename,p); /*dcr041023*/


### PR DESCRIPTION
Added CMakeLists.txt to enable compiling on various architectures using CMake.

Added binary flag to fopen() calls so that it will behave the same on Windows as on other platforms.